### PR TITLE
Set play-services-analytics to be +

### DIFF
--- a/plugin/platforms/android/include.gradle
+++ b/plugin/platforms/android/include.gradle
@@ -20,7 +20,7 @@ buildscript {
 
 dependencies {
     // [START gms_compile]
-    compile 'com.google.android.gms:play-services-analytics:9.2.0'
+    compile 'com.google.android.gms:play-services-analytics:+'
     // [END gms_compile]
 }
 


### PR DESCRIPTION
I believe that `com.google.android.gms:play-services-analytics` should be dynamic, instead of setting hardcoded. So the SDK will update to the newest version from google sdk. It should fix #12